### PR TITLE
init configs for robot2077_basic

### DIFF
--- a/robot2077/src/robot2077_basic/config/robot_avoidance.yaml
+++ b/robot2077/src/robot2077_basic/config/robot_avoidance.yaml
@@ -1,0 +1,2 @@
+avoidance_dis_max: 1.2
+avoidance_dis_min: 0.6

--- a/robot2077/src/robot2077_basic/config/robot_move.yaml
+++ b/robot2077/src/robot2077_basic/config/robot_move.yaml
@@ -1,0 +1,2 @@
+linear_vel_max: 1.0
+angular_vel_max: 1.0

--- a/robot2077/src/robot2077_basic/launch/robot_move.launch
+++ b/robot2077/src/robot2077_basic/launch/robot_move.launch
@@ -1,0 +1,8 @@
+<launch>
+
+    <rosparam file="$(find robot2077_basic)/config/robot_move.yaml" command="load" />
+    <node pkg="robot2077_basic" name="robot_move" type="robot_move">
+        
+    </node>
+    
+</launch>

--- a/robot2077/src/robot2077_basic/launch/robot_move_with_avoidance.launch
+++ b/robot2077/src/robot2077_basic/launch/robot_move_with_avoidance.launch
@@ -1,0 +1,11 @@
+<launch>
+
+    <rosparam file="$(find robot2077_basic)/config/robot_avoidance.yaml" command="load" />
+    <rosparam file="$(find robot2077_basic)/config/robot_move.yaml" command="load" />
+    <node pkg="robot2077_basic" name="robot_avoidance" type="robot_avoidance">
+
+    </node>
+    <node pkg="robot2077_basic" name="robot_move" type="robot_move">
+        
+    </node>
+</launch>

--- a/robot2077/src/robot2077_basic/src/robot_avoidance.cpp
+++ b/robot2077/src/robot2077_basic/src/robot_avoidance.cpp
@@ -3,8 +3,9 @@
 #include "robot2077_basic/IsAvoidance.h"
 #include "cmath"
 
-const float AVOIDANCE_DIS_MAX = 1.0;
-const float AVOIDANCE_DIS_MIN = 0.4;
+float AVOIDANCE_DIS_MAX = 1.0;
+float AVOIDANCE_DIS_MIN = 0.4;
+
 float range_cache[1000];
 int range_size;
 float range_angle_min, range_angle_max, range_angle_inc;
@@ -85,6 +86,9 @@ bool checkAvoidance(robot2077_basic::IsAvoidance::Request &req, robot2077_basic:
 int main(int argc, char **argv) {
     ros::init(argc, argv, "robot_avoidance");
     ros::NodeHandle n;
+    n.getParam("avoidance_dis_max", AVOIDANCE_DIS_MAX);
+    n.getParam("avoidance_dis_min", AVOIDANCE_DIS_MIN);
+    ROS_INFO("Loading param: avoidance_dis_max: %.2f, avoidance_dis_min: %.2f", AVOIDANCE_DIS_MAX, AVOIDANCE_DIS_MIN);
 
     ros::ServiceServer avoidanceServer = n.advertiseService("/robot2077/robot_move/is_avoidance", checkAvoidance);
     ROS_INFO("Robot Avoidance Server Start!");

--- a/robot2077/src/robot2077_basic/src/robot_move.cpp
+++ b/robot2077/src/robot2077_basic/src/robot_move.cpp
@@ -4,8 +4,8 @@
 #include "robot2077_basic/IsAvoidance.h"
 #include <iostream>
 
-const float LINEAR_VEL_MAX = 0.8;
-const float ANGULAR_VEL_MAX = 0.7;
+float LINEAR_VEL_MAX = 0.8;
+float ANGULAR_VEL_MAX = 0.7;
 
 ros::Publisher vel_pub;
 geometry_msgs::Twist vel_temp;
@@ -27,6 +27,10 @@ int main(int argc, char **argv) {
     ros::init(argc, argv, "robot_move");
     ros::NodeHandle n;
     
+    n.getParam("linear_vel_max", LINEAR_VEL_MAX);
+    n.getParam("angular_vel_max", ANGULAR_VEL_MAX);
+    ROS_INFO("Loading params, linear_vel_max: %.2f, angular_vel_max: %.2f", LINEAR_VEL_MAX, ANGULAR_VEL_MAX);
+
     vel_pub = n.advertise<geometry_msgs::Twist>("/cmd_vel", 10);
     checkAvoidance = n.serviceClient<robot2077_basic::IsAvoidance>("/robot2077/robot_move/is_avoidance");
 

--- a/robot2077/src/robot2077_listen/launch/include/user_listen.launch.xml
+++ b/robot2077/src/robot2077_listen/launch/include/user_listen.launch.xml
@@ -1,6 +1,6 @@
 <launch>
 
-    <node pkg="robot2077_basic" name="robot_move" type="robot_move"/>
+    <include file="$(find robot2077_basic)/launch/robot_move.launch" />
     <node pkg="robot2077_listen" name="user_listen" type="user_listen"/>
 
 </launch>

--- a/robot2077/src/robot2077_listen/launch/include/user_listen_with_avoidance.launch.xml
+++ b/robot2077/src/robot2077_listen/launch/include/user_listen_with_avoidance.launch.xml
@@ -1,5 +1,6 @@
 <launch>
-    <node pkg="robot2077_basic" name="robot_avoidance" type="robot_avoidance"/>
-    <node pkg="robot2077_basic" name="robot_move" type="robot_move"/>
+
+    <include file="$(find robot2077_basic)/launch/robot_move_with_avoidance.launch" />
     <node pkg="robot2077_listen" name="user_listen" type="user_listen"/>
+
 </launch>

--- a/robot2077/src/robot2077_listen/launch/user_keyboard_listen.launch
+++ b/robot2077/src/robot2077_listen/launch/user_keyboard_listen.launch
@@ -3,5 +3,5 @@
     <include file="$(find robot2077_listen)/launch/include/user_listen.launch.xml"/>
     <!--include file="$(find robot2077_listen)/launch/include/user_listen_with_avoidance.launch.xml"-->
     <!--开启键盘监听-->
-    <node pkg="robot2077_listen" name="keyboard" type="keyboard_listen.py"/>
+    <node pkg="robot2077_listen" name="keyboard" type="keyboard_listen.py" output="screen"/>
 </launch>

--- a/robot2077/src/robot2077_listen/launch/user_keyboard_listen_with_avoidance.launch
+++ b/robot2077/src/robot2077_listen/launch/user_keyboard_listen_with_avoidance.launch
@@ -3,5 +3,5 @@
     <!--include file="$(find robot2077_listen)/launch/include/user_listen.launch.xml"-->
     <include file="$(find robot2077_listen)/launch/include/user_listen_with_avoidance.launch.xml"/>
     <!--开启键盘监听-->
-    <node pkg="robot2077_listen" name="keyboard" type="keyboard_listen.py"/>
+    <node pkg="robot2077_listen" name="keyboard" type="keyboard_listen.py" output="screen" />
 </launch>


### PR DESCRIPTION
添加了参数配置文件，可以直接修改配置文件来修改参数了。
在robot2077_basic中添加了launch文件，现在建议使用launch文件运行robot_move和robot_avoidance节点。这样可以加载配置文件。
直接运行节点也是可以的，有默认参数，但是不建议直接使用。